### PR TITLE
fix(git): No dirty tree on branch switch

### DIFF
--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -294,7 +294,9 @@ impl GitRepo {
     pub fn switch(&mut self, name: &str) -> Result<(), git2::Error> {
         let branch = self.repo.find_branch(name, git2::BranchType::Local)?;
         self.repo.set_head(branch.get().name().unwrap())?;
-        self.repo.checkout_head(None)?;
+        let mut builder = git2::build::CheckoutBuilder::new();
+        builder.force();
+        self.repo.checkout_head(Some(&mut builder))?;
         Ok(())
     }
 }

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -242,10 +242,13 @@ fn switch() {
     }
 
     {
+        assert!(!repo.is_dirty());
+
         repo.switch("master").unwrap();
         let actual = repo.head_commit();
         let expected = repo.find_local_branch("master").unwrap();
         assert_eq!(actual.id, expected.id);
+        assert!(!repo.is_dirty());
     }
 
     temp.close().unwrap();


### PR DESCRIPTION
I noticed that after running `git-stack --pull`, my INDEX was set to an
old state.  I got the tests to reproduce this.  By adding force, it
seemed to go away.  It should be safe to force because we ensure the
tree is clean before doing anything.