### PR TITLE
fix(graph): Correctly merge disparaet trees

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -384,8 +384,7 @@ fn show(state: &State, colored_stdout: bool) -> eyre::Result<()> {
         Ok(root)
     })?;
     for other in roots {
-        let applied = root.extend(other?);
-        assert!(applied);
+        root = root.extend(&state.repo, other?)?;
     }
 
     git_stack::graph::pushable(&mut root)?;


### PR DESCRIPTION
I finally did multiple protected branches and merging panics because I
didn't plan for all cases.  We should now be good.