### PR TITLE
fix(graph): Don't stack unrelated branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Fixes
+
+- Don't stack unrelated branches (broken in 0.2.3)
+
 #### Features
 
 - Stack View

--- a/src/graph/actions.rs
+++ b/src/graph/actions.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Action {
     Pick,
     Protected,


### PR DESCRIPTION
When redoing the scripting logic, I missed the case for the very first
commit and ended up stacking all the branches off of it.