### PR TITLE
fix(graph): Panic on parent branch merge into child branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Fixes
+
+- Crash on merge of parent branch into child branch
+
 ## [0.2.5] - 2021-08-31
 
 #### Fixes

--- a/src/graph/node.rs
+++ b/src/graph/node.rs
@@ -159,12 +159,14 @@ impl Node {
         let first = commits.next().expect("always at lead HEAD");
         assert_eq!(first.id, head_oid);
 
-        for commit in commits {
-            let child = root;
-            root = Node::new(commit, branches);
-            root.children.insert(child.local_commit.id, child);
-            if root.local_commit.id == base_oid {
-                break;
+        if head_oid != base_oid {
+            for commit in commits {
+                let child = root;
+                root = Node::new(commit, branches);
+                root.children.insert(child.local_commit.id, child);
+                if root.local_commit.id == base_oid {
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
We had a crash because we merged a history dating back to the beginning
into a branch.  This happens because the "pre-historic" branch was
actually a parent branch and we skipped the condition for the branch to
end, so we only terminate at end of iteration.