### PR TITLE
fix!: Rename `git-branch-backup` to `git-branch-stash`

### DIFF
--- a/src/bin/git-branch-stash/args.rs
+++ b/src/bin/git-branch-stash/args.rs
@@ -21,65 +21,65 @@ pub struct Args {
 
 #[derive(structopt::StructOpt)]
 pub enum Subcommand {
-    /// Backup all branches
+    /// Stash all branches
     Push(PushArgs),
-    /// List all backups
+    /// List all stashed snapshots
     List(ListArgs),
-    /// Clear all backups
+    /// Clear all snapshots
     Clear(ClearArgs),
-    /// Delete the last backup
+    /// Delete the last snapshot
     Drop(DropArgs),
-    /// Apply the last backup, deleting it
+    /// Apply the last snapshot, deleting it
     Pop(PopArgs),
-    /// Apply the last backup
+    /// Apply the last snapshot
     Apply(ApplyArgs),
-    /// List all backup stacks
+    /// List all snapshot stacks
     Stacks(StacksArgs),
 }
 
 #[derive(structopt::StructOpt)]
 pub struct PushArgs {
-    /// Specify which backup stack to use
-    #[structopt(default_value = git_stack::backup::Stack::DEFAULT_STACK)]
+    /// Specify which stash stack to use
+    #[structopt(default_value = git_stack::stash::Stack::DEFAULT_STACK)]
     pub stack: String,
 
-    /// Annotate the backup with the given message
+    /// Annotate the snapshot with the given message
     #[structopt(short, long)]
     pub message: Option<String>,
 }
 
 #[derive(structopt::StructOpt)]
 pub struct ListArgs {
-    /// Specify which backup stack to use
-    #[structopt(default_value = git_stack::backup::Stack::DEFAULT_STACK)]
+    /// Specify which stash stack to use
+    #[structopt(default_value = git_stack::stash::Stack::DEFAULT_STACK)]
     pub stack: String,
 }
 
 #[derive(structopt::StructOpt)]
 pub struct ClearArgs {
-    /// Specify which backup stack to use
-    #[structopt(default_value = git_stack::backup::Stack::DEFAULT_STACK)]
+    /// Specify which stash stack to use
+    #[structopt(default_value = git_stack::stash::Stack::DEFAULT_STACK)]
     pub stack: String,
 }
 
 #[derive(structopt::StructOpt)]
 pub struct DropArgs {
-    /// Specify which backup stack to use
-    #[structopt(default_value = git_stack::backup::Stack::DEFAULT_STACK)]
+    /// Specify which stash stack to use
+    #[structopt(default_value = git_stack::stash::Stack::DEFAULT_STACK)]
     pub stack: String,
 }
 
 #[derive(structopt::StructOpt)]
 pub struct PopArgs {
-    /// Specify which backup stack to use
-    #[structopt(default_value = git_stack::backup::Stack::DEFAULT_STACK)]
+    /// Specify which stash stack to use
+    #[structopt(default_value = git_stack::stash::Stack::DEFAULT_STACK)]
     pub stack: String,
 }
 
 #[derive(structopt::StructOpt)]
 pub struct ApplyArgs {
-    /// Specify which backup stack to use
-    #[structopt(default_value = git_stack::backup::Stack::DEFAULT_STACK)]
+    /// Specify which stash stack to use
+    #[structopt(default_value = git_stack::stash::Stack::DEFAULT_STACK)]
     pub stack: String,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ static PUSH_REMOTE_FIELD: &str = "stack.push-remote";
 static PULL_REMOTE_FIELD: &str = "stack.pull-remote";
 static FORMAT_FIELD: &str = "stack.show-format";
 static STACKED_FIELD: &str = "stack.show-stacked";
-static BACKUP_CAPACITY_FIELD: &str = "branch-backup.capacity";
+static BACKUP_CAPACITY_FIELD: &str = "branch-stash.capacity";
 
 static DEFAULT_PROTECTED_BRANCHES: [&str; 4] = ["main", "master", "dev", "stable"];
 const DEFAULT_CAPACITY: usize = 30;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@
 #[macro_use]
 extern crate clap;
 
-pub mod backup;
 pub mod config;
 pub mod git;
 pub mod graph;
 pub mod log;
+pub mod stash;

--- a/src/stash/mod.rs
+++ b/src/stash/mod.rs
@@ -1,6 +1,6 @@
 #[allow(clippy::module_inception)]
-mod backup;
+mod snapshot;
 mod stack;
 
-pub use backup::*;
+pub use snapshot::*;
 pub use stack::*;

--- a/src/stash/snapshot.rs
+++ b/src/stash/snapshot.rs
@@ -1,12 +1,12 @@
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct Backup {
+pub struct Snapshot {
     pub branches: Vec<Branch>,
     #[serde(default)]
     #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
     pub metadata: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
-impl Backup {
+impl Snapshot {
     pub fn load(path: &std::path::Path) -> Result<Self, std::io::Error> {
         let file = std::fs::File::open(path)?;
         let reader = std::io::BufReader::new(file);


### PR DESCRIPTION
This framing helps clarify how someone is intended to use the command,
which makes sense considering it was modeled after `git stash`.