### PR TITLE
fix(graph): Gracefully handle squash-merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,8 @@ dependencies = [
  "bstr",
  "derive_more",
  "eyre",
+ "humantime",
+ "humantime-serde",
  "proc-exit",
  "schemars",
  "serde",
@@ -446,6 +448,22 @@ dependencies = [
  "termcolor",
  "toml",
  "uuid",
+]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "humantime-serde"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac34a56cfd4acddb469cc7fff187ed5ac36f498ba085caf8bbc725e3ff474058"
+dependencies = [
+ "humantime",
+ "serde",
 ]
 
 [[package]]

--- a/crates/git-fixture/Cargo.toml
+++ b/crates/git-fixture/Cargo.toml
@@ -11,6 +11,8 @@ edition = "2018"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+humantime = "2"
+humantime-serde = "1"
 bstr = { version = "0.2", features = ["serde1"] }
 derive_more = "0.99.0"
 eyre = "0.6"

--- a/crates/git-fixture/src/lib.rs
+++ b/crates/git-fixture/src/lib.rs
@@ -57,7 +57,7 @@ impl Dag {
         import_root: &std::path::Path,
         marks: &mut std::collections::HashMap<String, String>,
     ) -> eyre::Result<()> {
-        for event in events.into_iter() {
+        for event in events.iter() {
             match event {
                 Event::Import(path) => {
                     let path = import_root.join(path);
@@ -144,7 +144,7 @@ impl Dag {
                     let start_commit = current_oid(cwd)?;
                     for run in events {
                         checkout(cwd, &start_commit)?;
-                        self.run_events(&run, cwd, import_root, marks)?;
+                        self.run_events(run, cwd, import_root, marks)?;
                     }
                 }
                 Event::Head(reference) => {

--- a/crates/git-fixture/src/lib.rs
+++ b/crates/git-fixture/src/lib.rs
@@ -44,14 +44,15 @@ impl Dag {
         }
 
         let mut marks: std::collections::HashMap<String, String> = Default::default();
-        Self::run_events(self.events, cwd, &self.import_root, &mut marks)?;
+        self.run_events(&self.events, cwd, &self.import_root, &mut marks)?;
 
         Ok(())
     }
 
     // Note: shelling out to git to minimize programming bugs
     fn run_events(
-        events: Vec<Event>,
+        &self,
+        events: &[Event],
         cwd: &std::path::Path,
         import_root: &std::path::Path,
         marks: &mut std::collections::HashMap<String, String>,
@@ -62,6 +63,7 @@ impl Dag {
                     let path = import_root.join(path);
                     let mut child_dag = Dag::load(&path)?;
                     child_dag.init = false;
+                    child_dag.sleep = child_dag.sleep.or(self.sleep);
                     child_dag.run(cwd).wrap_err_with(|| {
                         format!("Failed when running imported fixcture {}", path.display())
                     })?;
@@ -113,6 +115,9 @@ impl Dag {
                             p.arg("--author").arg(author);
                         }
                         p.ok()?;
+                        if let Some(sleep) = self.sleep {
+                            std::thread::sleep(sleep);
+                        }
 
                         if let Some(branch) = tree.branch.as_ref() {
                             let _ = std::process::Command::new("git")
@@ -135,15 +140,11 @@ impl Dag {
                         }
                     }
                 }
-                Event::Children(mut events) => {
+                Event::Children(events) => {
                     let start_commit = current_oid(cwd)?;
-                    let last_run = events.pop();
                     for run in events {
-                        Self::run_events(run, cwd, import_root, marks)?;
                         checkout(cwd, &start_commit)?;
-                    }
-                    if let Some(last_run) = last_run {
-                        Self::run_events(last_run, cwd, import_root, marks)?;
+                        self.run_events(&run, cwd, import_root, marks)?;
                     }
                 }
                 Event::Head(reference) => {

--- a/crates/git-fixture/src/model.rs
+++ b/crates/git-fixture/src/model.rs
@@ -5,6 +5,10 @@ pub struct Dag {
     #[serde(default = "init_default")]
     pub init: bool,
     #[serde(default)]
+    #[serde(serialize_with = "humantime_serde::serialize")]
+    #[serde(deserialize_with = "humantime_serde::deserialize")]
+    pub sleep: Option<std::time::Duration>,
+    #[serde(default)]
     pub events: Vec<Event>,
     #[serde(skip)]
     pub import_root: std::path::PathBuf,

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -349,6 +349,7 @@ fn plan_rebase(state: &State, stack: &StackState) -> eyre::Result<git_stack::git
     git_stack::graph::protect_branches(&mut root, &state.repo, &state.protected_branches);
 
     git_stack::graph::rebase_branches(&mut root, stack.onto.id);
+    git_stack::graph::drop_by_tree_id(&mut root);
 
     let script = git_stack::graph::to_script(&root);
 
@@ -389,6 +390,7 @@ fn show(state: &State, colored_stdout: bool) -> eyre::Result<()> {
             if state.dry_run {
                 // Show as-if we performed all mutations
                 git_stack::graph::rebase_branches(&mut root, stack.onto.id);
+                git_stack::graph::drop_by_tree_id(&mut root);
             }
 
             eyre::Result::Ok(root)

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -687,7 +687,7 @@ fn drop_branches(
             if branch.name == potential_head {
                 continue;
             } else if head_branch_name == Some(branch.name.as_str()) {
-                // Dom't leave HEAD detached but instead switch to the branch we pulled
+                // Don't leave HEAD detached but instead switch to the branch we pulled
                 log::trace!("git switch {}", potential_head);
                 if !dry_run {
                     repo.switch(potential_head)?;

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -340,7 +340,11 @@ pub fn stack(args: &crate::args::Args, colored_stdout: bool) -> proc_exit::ExitR
 
 fn plan_rebase(state: &State, stack: &StackState) -> eyre::Result<git_stack::git::Script> {
     let mut graphed_branches = stack.graphed_branches();
-    let mut root = git_stack::graph::Node::new(state.head_commit.clone(), &mut graphed_branches);
+    let base_commit = state
+        .repo
+        .find_commit(stack.base.id)
+        .expect("base branch is valid");
+    let mut root = git_stack::graph::Node::new(base_commit, &mut graphed_branches);
     root = root.extend_branches(&state.repo, graphed_branches)?;
     git_stack::graph::protect_branches(&mut root, &state.repo, &state.protected_branches);
 
@@ -374,8 +378,11 @@ fn show(state: &State, colored_stdout: bool) -> eyre::Result<()> {
         .iter()
         .map(|stack| -> eyre::Result<git_stack::graph::Node> {
             let mut graphed_branches = stack.graphed_branches();
-            let mut root =
-                git_stack::graph::Node::new(state.head_commit.clone(), &mut graphed_branches);
+            let base_commit = state
+                .repo
+                .find_commit(stack.base.id)
+                .expect("base branch is valid");
+            let mut root = git_stack::graph::Node::new(base_commit, &mut graphed_branches);
             root = root.extend_branches(&state.repo, graphed_branches)?;
             git_stack::graph::protect_branches(&mut root, &state.repo, &state.protected_branches);
 

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -1194,7 +1194,7 @@ fn format_commit_status<'d>(
     if node.action.is_protected() {
         format!("")
     } else if node.action.is_delete() {
-        format!("{} ", palette.warn.paint("(drop)"))
+        format!("{} ", palette.error.paint("(drop)"))
     } else if 1 < repo
         .raw()
         .find_commit(node.local_commit.id)

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -77,6 +77,13 @@ impl Commit {
                 .next()
         }
     }
+
+    pub fn revert_summary(&self) -> Option<&bstr::BStr> {
+        self.summary
+            .strip_prefix(b"Revert ")
+            .and_then(|s| s.strip_suffix(b"\""))
+            .map(ByteSlice::as_bstr)
+    }
 }
 
 pub struct GitRepo {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -44,6 +44,7 @@ pub struct Branch {
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Commit {
     pub id: git2::Oid,
+    pub tree_id: git2::Oid,
     pub summary: bstr::BString,
 }
 
@@ -152,6 +153,7 @@ impl GitRepo {
             let summary: bstr::BString = commit.summary_bytes().unwrap().into();
             let commit = std::rc::Rc::new(Commit {
                 id: commit.id(),
+                tree_id: commit.tree_id(),
                 summary,
             });
             commits.insert(id, std::rc::Rc::clone(&commit));

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -179,6 +179,8 @@ fn drop_first_branch_by_tree_id(
     node: &mut Node,
     protected_tree_ids: std::collections::HashSet<git2::Oid>,
 ) -> bool {
+    #![allow(clippy::if_same_then_else)]
+
     assert!(!node.action.is_protected());
     if node.branches.is_empty() {
         match node.children.len() {

--- a/tests/fixture.rs
+++ b/tests/fixture.rs
@@ -33,6 +33,7 @@ fn populate_event(
                 let summary = message.lines().next().unwrap().to_owned();
                 let commit = git_stack::git::Commit {
                     id: commit_id,
+                    tree_id: commit_id,
                     summary: bstr::BString::from(summary),
                 };
                 repo.push_commit(parent_id, commit);

--- a/tests/fixtures/git_rebase_existing.yml
+++ b/tests/fixtures/git_rebase_existing.yml
@@ -1,0 +1,35 @@
+init: true
+events:
+- tree:
+    tracked:
+      "file_a.txt": "1"
+    message: "1"
+    branch: initial
+- tree:
+    tracked:
+      "file_a.txt": "2"
+    message: "2"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+    message: "3"
+    branch: master
+- children:
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+        message: "7"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "2"
+        message: "8"
+        branch: feature2
+  # `git rebase master` caused the history to split
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+        message: "7"
+        branch: feature1

--- a/tests/fixtures/git_rebase_new.yml
+++ b/tests/fixtures/git_rebase_new.yml
@@ -1,0 +1,36 @@
+init: true
+events:
+- tree:
+    tracked:
+      "file_a.txt": "1"
+    message: "1"
+    branch: initial
+- tree:
+    tracked:
+      "file_a.txt": "2"
+    message: "2"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+    message: "3"
+    branch: master
+- children:
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+        message: "7"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+          "file_c.txt": "1"
+        message: "8"
+        branch: feature2
+  # `git rebase master` caused the history to split
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+        message: "7"
+        branch: feature1

--- a/tests/fixtures/pr-semi-linear-merge.yml
+++ b/tests/fixtures/pr-semi-linear-merge.yml
@@ -1,0 +1,81 @@
+init: true
+events:
+- tree:
+    tracked:
+      "file_a.txt": "1"
+    message: "1"
+    branch: initial
+- tree:
+    tracked:
+      "file_a.txt": "2"
+    message: "2"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+    message: "3"
+    branch: base
+- children:
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+        message: "4"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "2"
+        message: "5"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+        message: "6"
+        branch: old_master
+    # AzDO has the "semi-linear merge" type which rebases the branch before merging
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+          "file_c.txt": "1"
+        message: "7"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+          "file_c.txt": "2"
+        message: "8"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+          "file_c.txt": "3"
+        message: "9"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+          "file_c.txt": "4"
+        message: "10"
+        branch: master
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "1"
+        message: "7"
+        branch: feature1
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "2"
+        message: "8"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "3"
+        message: "9"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "4"
+        message: "10"
+        branch: feature2

--- a/tests/fixtures/pr-squash.yml
+++ b/tests/fixtures/pr-squash.yml
@@ -1,0 +1,63 @@
+init: true
+events:
+- tree:
+    tracked:
+      "file_a.txt": "1"
+    message: "1"
+    branch: initial
+- tree:
+    tracked:
+      "file_a.txt": "2"
+    message: "2"
+- tree:
+    tracked:
+      "file_a.txt": "3"
+    message: "3"
+    branch: base
+- children:
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "1"
+        message: "4"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "2"
+        message: "5"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+        message: "6"
+        branch: old_master
+    # Squashed "feature2" into a single commit and committed it onto master
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_b.txt": "3"
+          "file_c.txt": "4"
+        message: "Merged #10"
+        branch: master
+  - - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "1"
+        message: "7"
+        branch: feature1
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "2"
+        message: "8"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "3"
+        message: "9"
+    - tree:
+        tracked:
+          "file_a.txt": "3"
+          "file_c.txt": "4"
+        message: "10"
+        branch: feature2

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -37,7 +37,7 @@ fn shared_fixture() {
     {
         {
             let one = repo.find_local_branch("feature1").unwrap();
-            let two = repo.find_local_branch("feature1").unwrap();
+            let two = repo.find_local_branch("feature2").unwrap();
 
             let actual = repo.merge_base(one.id, two.id).unwrap();
             assert_eq!(actual, one.id);

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -178,6 +178,29 @@ fn cherry_pick_conflict() {
 }
 
 #[test]
+fn squash_clean() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let plan = git_fixture::Dag::load(std::path::Path::new("tests/fixtures/branches.yml")).unwrap();
+    plan.run(temp.path()).unwrap();
+
+    let repo = git2::Repository::discover(temp.path()).unwrap();
+    let mut repo = GitRepo::new(repo);
+
+    {
+        assert!(!repo.is_dirty());
+
+        let base = repo.find_local_branch("master").unwrap();
+        let source = repo.find_local_branch("feature2").unwrap();
+        let dest_id = repo.squash(source.id, base.id).unwrap();
+
+        repo.branch("squashed", dest_id).unwrap();
+        assert!(!repo.is_dirty());
+    }
+
+    temp.close().unwrap();
+}
+
+#[test]
 fn branch() {
     let temp = assert_fs::TempDir::new().unwrap();
     let plan = git_fixture::Dag::load(std::path::Path::new("tests/fixtures/branches.yml")).unwrap();


### PR DESCRIPTION
Before, when doing a `git-stack --pull`, we'd rebase the merged branch
onto master.  `git` would the automatically detect the commit is merged
and drop it.  We'd then associate the branch name with the same commit
master points to and have to delete it manually.

This tries to detect that case so we can automatically delete the stale
branch on behalf of users.

This does not help if your branch is behind master because those extra
commits will impact how we are detecting this case (tree id).

This is a spiritual revert of 80f5158,
re-implementing 892117b to handle all
of our changes and with a little more experience and context.

This is a part of #28.