### PR TITLE
feat: Add `--squash=<action>` support

### DIFF
--- a/src/bin/git-stack/args.rs
+++ b/src/bin/git-stack/args.rs
@@ -36,6 +36,14 @@ pub struct Args {
     #[structopt(long)]
     pub onto: Option<String>,
 
+    /// Action to perform with fixup-commits
+    #[structopt(
+        long,
+        possible_values(&git_stack::config::Fixup::variants()),
+        case_insensitive(true),
+    )]
+    pub fixup: Option<git_stack::config::Fixup>,
+
     #[structopt(short = "n", long)]
     pub dry_run: bool,
 
@@ -74,6 +82,7 @@ impl Args {
             pull_remote: None,
             show_format: self.format,
             show_stacked: None,
+            fixup: self.fixup,
 
             capacity: None,
         }

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -367,12 +367,7 @@ fn plan_rebase(state: &State, stack: &StackState) -> eyre::Result<git_stack::git
 
     git_stack::graph::rebase_branches(&mut root, stack.onto.id);
     git_stack::graph::drop_by_tree_id(&mut root);
-    match state.fixup {
-        git_stack::config::Fixup::Ignore => (),
-        git_stack::config::Fixup::Move => {
-            git_stack::graph::fixup(&mut root);
-        }
-    }
+    git_stack::graph::fixup(&mut root, state.fixup);
 
     let script = git_stack::graph::to_script(&root);
 
@@ -414,12 +409,7 @@ fn show(state: &State, colored_stdout: bool) -> eyre::Result<()> {
                 // Show as-if we performed all mutations
                 git_stack::graph::rebase_branches(&mut root, stack.onto.id);
                 git_stack::graph::drop_by_tree_id(&mut root);
-                match state.fixup {
-                    git_stack::config::Fixup::Ignore => (),
-                    git_stack::config::Fixup::Move => {
-                        git_stack::graph::fixup(&mut root);
-                    }
-                }
+                git_stack::graph::fixup(&mut root, state.fixup);
             }
 
             eyre::Result::Ok(root)

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -16,6 +16,7 @@ struct State {
     rebase: bool,
     pull: bool,
     push: bool,
+    fixup: git_stack::config::Fixup,
     dry_run: bool,
     snapshot_capacity: Option<usize>,
 
@@ -38,6 +39,21 @@ impl State {
             log::trace!("`--pull` implies `--rebase`");
             rebase = true;
         }
+        let rebase = rebase;
+
+        let fixup = if args.fixup.is_some() || rebase {
+            repo_config.fixup()
+        } else {
+            // Assume the user is only wanting to show the tree and not modify it.
+            let no_op = git_stack::config::Fixup::Ignore;
+            if no_op != repo_config.fixup() {
+                log::trace!(
+                    "Ignoring `fixup={}` without an explicit `--rebase` or `--fixup`",
+                    repo_config.fixup()
+                );
+            }
+            no_op
+        };
         let push = args.push;
         let protected = git_stack::git::ProtectedBranches::new(
             repo_config.protected_branches().iter().map(|s| s.as_str()),
@@ -155,6 +171,7 @@ impl State {
             rebase,
             pull,
             push,
+            fixup,
             dry_run,
             snapshot_capacity,
 
@@ -350,6 +367,12 @@ fn plan_rebase(state: &State, stack: &StackState) -> eyre::Result<git_stack::git
 
     git_stack::graph::rebase_branches(&mut root, stack.onto.id);
     git_stack::graph::drop_by_tree_id(&mut root);
+    match state.fixup {
+        git_stack::config::Fixup::Ignore => (),
+        git_stack::config::Fixup::Move => {
+            git_stack::graph::fixup(&mut root);
+        }
+    }
 
     let script = git_stack::graph::to_script(&root);
 
@@ -391,6 +414,12 @@ fn show(state: &State, colored_stdout: bool) -> eyre::Result<()> {
                 // Show as-if we performed all mutations
                 git_stack::graph::rebase_branches(&mut root, stack.onto.id);
                 git_stack::graph::drop_by_tree_id(&mut root);
+                match state.fixup {
+                    git_stack::config::Fixup::Ignore => (),
+                    git_stack::config::Fixup::Move => {
+                        git_stack::graph::fixup(&mut root);
+                    }
+                }
             }
 
             eyre::Result::Ok(root)

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct RepoConfig {
     pub pull_remote: Option<String>,
     pub show_format: Option<Format>,
     pub show_stacked: Option<bool>,
+    pub fixup: Option<Fixup>,
 
     pub capacity: Option<usize>,
 }
@@ -19,6 +20,7 @@ static PUSH_REMOTE_FIELD: &str = "stack.push-remote";
 static PULL_REMOTE_FIELD: &str = "stack.pull-remote";
 static FORMAT_FIELD: &str = "stack.show-format";
 static STACKED_FIELD: &str = "stack.show-stacked";
+static FIXUP_FIELD: &str = "stack.fixup";
 static BACKUP_CAPACITY_FIELD: &str = "branch-stash.capacity";
 
 static DEFAULT_PROTECTED_BRANCHES: [&str; 4] = ["main", "master", "dev", "stable"];
@@ -127,6 +129,10 @@ impl RepoConfig {
                 }
             } else if key == STACKED_FIELD {
                 config.show_stacked = Some(value.as_ref().map(|v| v == "true").unwrap_or(true));
+            } else if key == FIXUP_FIELD {
+                if let Some(value) = value.as_ref().and_then(|v| FromStr::from_str(v).ok()) {
+                    config.fixup = Some(value);
+                }
             } else if key == BACKUP_CAPACITY_FIELD {
                 config.capacity = value.as_deref().and_then(|s| s.parse::<usize>().ok());
             } else {
@@ -208,6 +214,12 @@ impl RepoConfig {
             .and_then(|s| FromStr::from_str(s).ok());
 
         let show_stacked = config.get_bool(STACKED_FIELD).ok();
+
+        let fixup = config
+            .get_str(FIXUP_FIELD)
+            .ok()
+            .and_then(|s| FromStr::from_str(s).ok());
+
         let capacity = config
             .get_i64(BACKUP_CAPACITY_FIELD)
             .map(|i| i as usize)
@@ -220,6 +232,7 @@ impl RepoConfig {
             stack,
             show_format,
             show_stacked,
+            fixup,
 
             capacity,
         }
@@ -288,6 +301,10 @@ impl RepoConfig {
         self.show_stacked.unwrap_or(true)
     }
 
+    pub fn fixup(&self) -> Fixup {
+        self.fixup.unwrap_or_else(Default::default)
+    }
+
     pub fn capacity(&self) -> Option<usize> {
         let capacity = self.capacity.unwrap_or(DEFAULT_CAPACITY);
         (capacity != 0).then(|| capacity)
@@ -334,6 +351,12 @@ impl std::fmt::Display for RepoConfig {
             "\t{}={}",
             STACKED_FIELD.split_once(".").unwrap().1,
             self.show_stacked()
+        )?;
+        writeln!(
+            f,
+            "\t{}={}",
+            FIXUP_FIELD.split_once(".").unwrap().1,
+            self.fixup()
         )?;
         writeln!(f, "[{}]", BACKUP_CAPACITY_FIELD.split_once(".").unwrap().0)?;
         writeln!(
@@ -386,5 +409,20 @@ arg_enum! {
 impl Default for Stack {
     fn default() -> Self {
         Stack::All
+    }
+}
+
+arg_enum! {
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "kebab-case")]
+    pub enum Fixup {
+        Ignore,
+        Move,
+    }
+}
+
+impl Default for Fixup {
+    fn default() -> Self {
+        Fixup::Move
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -418,6 +418,7 @@ arg_enum! {
     pub enum Fixup {
         Ignore,
         Move,
+        Squash,
     }
 }
 

--- a/src/graph/actions.rs
+++ b/src/graph/actions.rs
@@ -1,6 +1,7 @@
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Action {
     Pick,
+    Squash,
     Protected,
     Delete,
 }
@@ -8,6 +9,10 @@ pub enum Action {
 impl Action {
     pub fn is_pick(&self) -> bool {
         matches!(self, Action::Pick)
+    }
+
+    pub fn is_squash(&self) -> bool {
+        matches!(self, Action::Squash)
     }
 
     pub fn is_protected(&self) -> bool {

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -216,9 +216,13 @@ fn drop_first_branch_by_tree_id(
     }
 }
 
-pub fn fixup(node: &mut Node) {
+pub fn fixup(node: &mut Node, effect: crate::config::Fixup) {
+    if effect == crate::config::Fixup::Ignore {
+        return;
+    }
+
     let mut outstanding = std::collections::BTreeMap::new();
-    fixup_nodes(node, &mut outstanding);
+    fixup_nodes(node, effect, &mut outstanding);
     if !outstanding.is_empty() {
         assert!(!node.action.is_protected());
         for nodes in outstanding.into_values() {
@@ -232,11 +236,12 @@ pub fn fixup(node: &mut Node) {
 
 fn fixup_nodes(
     node: &mut Node,
+    effect: crate::config::Fixup,
     outstanding: &mut std::collections::BTreeMap<bstr::BString, Vec<Node>>,
 ) {
     let mut fixups = Vec::new();
     for (id, child) in node.children.iter_mut() {
-        fixup_nodes(child, outstanding);
+        fixup_nodes(child, effect, outstanding);
 
         if child.action.is_protected() || child.action.is_delete() {
             continue;


### PR DESCRIPTION
This removes another workflow papercut where someone has to drop to `git rebase -i` to take care of fixup commits which might mess up their stacks.  Now, we can clean it all up while preserving their stacks.

Fixes #7 
Fixes #9