### PR TITLE
feat(graph): Avoid showing old branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,7 @@ dependencies = [
  "git-fixture",
  "git2",
  "human-panic",
+ "humantime",
  "ignore",
  "itertools",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ concolor-clap = { version = "0.0.6", features = ["api_unstable"] }
 termtree = "0.2"
 env_logger = { version = "0.9", default-features = false, features = ["termcolor"] }
 atty = "0.2"
+humantime = "2"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -123,6 +123,7 @@ Configuration is read from the following (in precedence order):
 |------------------------|----------|----------------------------|-------------|
 | stack.protected-branch | \-       | multivar of globs          | Branch names that match these globs (`.gitignore` syntax) are considered protected branches |
 | stack.protect-commit-count | \-   | integer                    | Protect commits that are on a branch with `count`+ commits |
+| stack.protect-commit-age | \-     | time delta (e.g. 10days)   | Protect commits that older than the specified time |
 | stack.stack            | --stack  | "current", "dependents", "descendants", "all" | Which development branch-stacks to operate on |
 | stack.push-remote      | \-       | string                     | Development remote for pushing local branches |
 | stack.pull-remote      | \-       | string                     | Upstream remote for pulling protected branches |

--- a/src/bin/git-stack/args.rs
+++ b/src/bin/git-stack/args.rs
@@ -78,6 +78,7 @@ impl Args {
         git_stack::config::RepoConfig {
             protected_branches: None,
             protect_commit_count: None,
+            protect_commit_age: None,
             stack: self.stack,
             push_remote: None,
             pull_remote: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use std::str::FromStr;
 
-#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Default, Clone, Debug)]
 pub struct RepoConfig {
     pub protected_branches: Option<Vec<String>>,
     pub protect_commit_count: Option<usize>,
@@ -406,8 +405,7 @@ fn default_branch(config: &git2::Config) -> &str {
     config.get_str("init.defaultBranch").ok().unwrap_or("main")
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Format {
     Silent,
     Branches,
@@ -454,8 +452,7 @@ impl Default for Format {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Stack {
     Current,
     Dependents,
@@ -499,8 +496,7 @@ impl Default for Stack {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "kebab-case")]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Fixup {
     Ignore,
     Move,

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,6 +295,7 @@ impl RepoConfig {
             (None, Some(rhs)) => self.protected_branches = Some(rhs),
             (_, _) => (),
         }
+        self.protect_commit_count = other.protect_commit_count.or(self.protect_commit_count);
         self.protect_commit_age = other.protect_commit_age.or(self.protect_commit_age);
         self.push_remote = other.push_remote.or(self.push_remote);
         self.pull_remote = other.pull_remote.or(self.pull_remote);

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -49,6 +49,7 @@ pub struct Commit {
     pub id: git2::Oid,
     pub tree_id: git2::Oid,
     pub summary: bstr::BString,
+    pub time: std::time::SystemTime,
 }
 
 impl Commit {
@@ -161,10 +162,13 @@ impl GitRepo {
         } else {
             let commit = self.repo.find_commit(id).ok()?;
             let summary: bstr::BString = commit.summary_bytes().unwrap().into();
+            let time = std::time::SystemTime::UNIX_EPOCH
+                + std::time::Duration::from_secs(commit.time().seconds().max(0) as u64);
             let commit = std::rc::Rc::new(Commit {
                 id: commit.id(),
                 tree_id: commit.tree_id(),
                 summary,
+                time,
             });
             commits.insert(id, std::rc::Rc::clone(&commit));
             Some(commit)

--- a/tests/fixture.rs
+++ b/tests/fixture.rs
@@ -35,6 +35,7 @@ fn populate_event(
                     id: commit_id,
                     tree_id: commit_id,
                     summary: bstr::BString::from(summary),
+                    time: std::time::SystemTime::now(),
                 };
                 repo.push_commit(parent_id, commit);
 


### PR DESCRIPTION
This is a step towards #111.  For now, we are collapsing old branches
into a single item and still showing their merge-base.  We will not try
to rebase them or process fixups.

Unlike `-count`, we are not listing the names of those branches with a
message about the age because I'm assuming we'll soon get this to the
ideal state where we list these branches like we do empty stacks.