### PR TITLE
perf(cli): Only prune remote dev branches

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -274,7 +274,7 @@ pub fn stack(
             .collect();
         push_branches.sort_unstable();
         if !push_branches.is_empty() {
-            match git_fetch_development(&mut state.repo, &push_branches, state.dry_run) {
+            match git_prune_development(&mut state.repo, &push_branches, state.dry_run) {
                 Ok(_) => (),
                 Err(err) => {
                     log::warn!("Skipping fetch of `{}`, {}", state.repo.push_remote(), err);
@@ -674,7 +674,7 @@ fn resolve_implicit_base(
     Ok(branch.clone())
 }
 
-fn git_fetch_development(
+fn git_prune_development(
     repo: &mut git_stack::git::GitRepo,
     branches: &[&str],
     dry_run: bool,
@@ -713,25 +713,6 @@ fn git_fetch_development(
                     .find_branch(&remote_branch, git2::BranchType::Remote)?;
                 branch.delete()?;
             }
-        }
-    }
-
-    if remote_branches.is_empty() {
-        return Ok(());
-    }
-
-    log::debug!("git fetch {} {}", remote, remote_branches.join(" "));
-    if !dry_run {
-        // A little uncertain about some of the weirder authentication needs, just deferring to `git`
-        // instead of using `libgit2`
-        let status = std::process::Command::new("git")
-            .arg("fetch")
-            .arg(remote)
-            .args(remote_branches)
-            .status()
-            .wrap_err("Could not run `git fetch`")?;
-        if !status.success() {
-            eyre::bail!("`git fetch {} {}` failed", remote, branches.join(" "));
         }
     }
 

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -697,6 +697,7 @@ fn git_prune_development(
         eyre::bail!("Could not run `git fetch`");
     }
     let stdout = String::from_utf8(output.stdout).wrap_err("Could not run `git fetch`")?;
+    #[allow(clippy::needless_collect)]
     let remote_branches: Vec<_> = stdout
         .lines()
         .filter_map(|l| l.rsplit_once('/'))

--- a/src/config.rs
+++ b/src/config.rs
@@ -343,11 +343,11 @@ impl RepoConfig {
     }
 
     pub fn stack(&self) -> Stack {
-        self.stack.unwrap_or_else(Default::default)
+        self.stack.unwrap_or_default()
     }
 
     pub fn show_format(&self) -> Format {
-        self.show_format.unwrap_or_else(Default::default)
+        self.show_format.unwrap_or_default()
     }
 
     pub fn show_stacked(&self) -> bool {
@@ -355,7 +355,7 @@ impl RepoConfig {
     }
 
     pub fn auto_fixup(&self) -> Fixup {
-        self.auto_fixup.unwrap_or_else(Default::default)
+        self.auto_fixup.unwrap_or_default()
     }
 
     pub fn auto_repair(&self) -> bool {


### PR DESCRIPTION
Realized that we don't care about the remote's state except for what can
be pruned, so going ahead and limiting ourselves to just that.