### PR TITLE
fix(cli): Do not auto-protect HEAD

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -420,9 +420,13 @@ fn plan_changes(state: &State, stack: &StackState) -> eyre::Result<git_stack::gi
     if let Some(protect_commit_count) = state.protect_commit_count {
         git_stack::graph::protect_large_branches(&mut graph, protect_commit_count);
     }
-    git_stack::graph::protect_old_branches(&mut graph, state.protect_commit_time);
+    git_stack::graph::protect_old_branches(
+        &mut graph,
+        state.protect_commit_time,
+        &[state.head_commit.id],
+    );
     if let Some(user) = state.repo.user() {
-        git_stack::graph::protect_foreign_branches(&mut graph, &user);
+        git_stack::graph::protect_foreign_branches(&mut graph, &user, &[state.head_commit.id]);
     }
 
     let mut dropped_branches = Vec::new();
@@ -486,9 +490,13 @@ fn push(state: &mut State) -> eyre::Result<()> {
     if let Some(protect_commit_count) = state.protect_commit_count {
         git_stack::graph::protect_large_branches(&mut graph, protect_commit_count);
     }
-    git_stack::graph::protect_old_branches(&mut graph, state.protect_commit_time);
+    git_stack::graph::protect_old_branches(
+        &mut graph,
+        state.protect_commit_time,
+        &[state.head_commit.id],
+    );
     if let Some(user) = state.repo.user() {
-        git_stack::graph::protect_foreign_branches(&mut graph, &user);
+        git_stack::graph::protect_foreign_branches(&mut graph, &user, &[state.head_commit.id]);
     }
 
     git_stack::graph::pushable(&mut graph);

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -120,7 +120,11 @@ fn mark_branch_protected(graph: &mut Graph, node_id: git2::Oid, branches: &mut V
     }
 }
 
-pub fn protect_old_branches(graph: &mut Graph, earlier_than: std::time::SystemTime) -> Vec<String> {
+pub fn protect_old_branches(
+    graph: &mut Graph,
+    earlier_than: std::time::SystemTime,
+    ignore: &[git2::Oid],
+) -> Vec<String> {
     let mut old_branches = Vec::new();
 
     let mut protected_queue = VecDeque::new();
@@ -139,7 +143,7 @@ pub fn protect_old_branches(graph: &mut Graph, earlier_than: std::time::SystemTi
             if child_action.is_protected() {
                 protected_queue.push_back(child_id);
             } else {
-                if is_branch_old(graph, child_id, earlier_than, &[]) {
+                if is_branch_old(graph, child_id, earlier_than, ignore) {
                     mark_branch_protected(graph, child_id, &mut old_branches);
                 }
             }
@@ -214,7 +218,11 @@ fn is_branch_old(
     true
 }
 
-pub fn protect_foreign_branches(graph: &mut Graph, user: &str) -> Vec<String> {
+pub fn protect_foreign_branches(
+    graph: &mut Graph,
+    user: &str,
+    ignore: &[git2::Oid],
+) -> Vec<String> {
     let mut foreign_branches = Vec::new();
 
     let mut protected_queue = VecDeque::new();
@@ -233,7 +241,7 @@ pub fn protect_foreign_branches(graph: &mut Graph, user: &str) -> Vec<String> {
             if child_action.is_protected() {
                 protected_queue.push_back(child_id);
             } else {
-                if !is_personal_branch(graph, child_id, user, &[]) {
+                if !is_personal_branch(graph, child_id, user, ignore) {
                     mark_branch_protected(graph, child_id, &mut foreign_branches);
                 }
             }

--- a/tests/graph.rs
+++ b/tests/graph.rs
@@ -354,7 +354,7 @@ fn overflow() {
     let mut graph = git_stack::graph::Graph::from_branches(&repo, graphed_branches).unwrap();
     git_stack::graph::protect_branches(&mut graph, &repo, &protected_branches);
     git_stack::graph::protect_large_branches(&mut graph, 50);
-    git_stack::graph::protect_foreign_branches(&mut graph, "Myself");
+    git_stack::graph::protect_foreign_branches(&mut graph, "Myself", &[]);
 
     git_stack::graph::fixup(&mut graph, git_stack::config::Fixup::Move);
 


### PR DESCRIPTION
Before, we auto-protect all old branches or those from another user.  As
pointed out in #107, sometimes you want to ressurect or take over those
branches but `git-stack` doesn't support this.  You either have to
disable these features or use raw git commands.

Now, we will never auto-protect HEAD, allowing editing of it.