### PR TITLE
fix(git): Don't prune valid remote branches

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -730,8 +730,8 @@ fn git_prune_development(
     #[allow(clippy::needless_collect)]
     let remote_branches: Vec<_> = stdout
         .lines()
-        .filter_map(|l| l.rsplit_once('/'))
-        .map(|s| s.1)
+        .filter_map(|l| l.split_once('\t').map(|s| s.1))
+        .filter_map(|l| l.strip_prefix("refs/heads/"))
         .collect();
 
     for branch in branches {


### PR DESCRIPTION
When deciding what to prune, we use `git ls-remote` to see what is
present.  When parsing the output, instead of processing the individual
fields, I took the shortcut of `rsplit_once('/')` which returned the
incorrect name for `names/with/slashes`.

Now we parse it more correctly.

Fixes #161